### PR TITLE
chore: In mobile, use the latest gnonative NPM package

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -14,7 +14,7 @@
         "@bufbuild/protobuf": "^1.6.0",
         "@connectrpc/connect": "^1.2.1",
         "@connectrpc/connect-web": "^1.2.1",
-        "@gnolang/gnonative": "^1.4.0",
+        "@gnolang/gnonative": "^1.6.0",
         "@reduxjs/toolkit": "^2.1.0",
         "base-64": "^1.0.0",
         "date-fns": "^3.6.0",
@@ -3562,9 +3562,9 @@
       }
     },
     "node_modules/@gnolang/gnonative": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@gnolang/gnonative/-/gnonative-1.4.0.tgz",
-      "integrity": "sha512-n4XqnUDcC7knfO7eYvDjM4oHZkFYsc+jwkKirOP/Wf8nkbJfuWL9khgT5ffwH4I8FxxrzkainTfunS4FvGa2Mw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@gnolang/gnonative/-/gnonative-1.6.0.tgz",
+      "integrity": "sha512-HfpUuVB4jln01rJiaLLt4sGrfHC4OREBK5mx8zzLc8NpMOsk3V7jvHqrxDEE2+ZeBnEUYgqw4EWK8HsAFqzQfg==",
       "dependencies": {
         "@buf/gnolang_gnonative.bufbuild_es": "^1.10.0-20240722123703-a858ea7341d6.1",
         "@buf/gnolang_gnonative.connectrpc_es": "^1.4.0-20240722123703-a858ea7341d6.3",

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -2408,8 +2408,8 @@
       }
     },
     "node_modules/@buf/gnolang_gnonative.bufbuild_es": {
-      "version": "1.9.0-20240430140846-fe9f3938584d.1",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/gnolang_gnonative.bufbuild_es/-/gnolang_gnonative.bufbuild_es-1.9.0-20240430140846-fe9f3938584d.1.tgz",
+      "version": "1.9.0-20240802120211-5c73abc17c66.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/gnolang_gnonative.bufbuild_es/-/gnolang_gnonative.bufbuild_es-1.9.0-20240802120211-5c73abc17c66.2.tgz",
       "peerDependencies": {
         "@bufbuild/protobuf": "^1.9.0"
       }

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -17,7 +17,7 @@
     "@bufbuild/protobuf": "^1.6.0",
     "@connectrpc/connect": "^1.2.1",
     "@connectrpc/connect-web": "^1.2.1",
-    "@gnolang/gnonative": "^1.4.0",
+    "@gnolang/gnonative": "^1.6.0",
     "@reduxjs/toolkit": "^2.1.0",
     "base-64": "^1.0.0",
     "date-fns": "^3.6.0",
@@ -25,11 +25,13 @@
     "expo-application": "~5.9.1",
     "expo-clipboard": "~6.0.3",
     "expo-constants": "~16.0.2",
+    "expo-dev-client": "~4.0.18",
     "expo-device": "~6.0.2",
     "expo-linear-gradient": "~13.0.2",
     "expo-linking": "~6.3.1",
     "expo-notifications": "~0.28.6",
     "expo-router": "~3.5.14",
+    "expo-secure-store": "~13.0.2",
     "expo-splash-screen": "~0.27.4",
     "expo-status-bar": "~1.12.1",
     "install": "^0.13.0",
@@ -49,9 +51,7 @@
     "react-redux": "^9.1.0",
     "styled-components": "^6.1.8",
     "text-encoding": "^0.7.0",
-    "web-streams-polyfill": "^3.3.2",
-    "expo-dev-client": "~4.0.18",
-    "expo-secure-store": "~13.0.2"
+    "web-streams-polyfill": "^3.3.2"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",


### PR DESCRIPTION
The latest NPM package supports the flag start_gnokey_mobile_service