### PR TITLE
fix: Use the latest gnonative to call ClientSignTx

### DIFF
--- a/api/gen/csharp/GnokeyMobileRpcGrpc.cs
+++ b/api/gen/csharp/GnokeyMobileRpcGrpc.cs
@@ -120,8 +120,8 @@ namespace Land.Gno.GnokeyMobile.V1 {
       }
 
       /// <summary>
-      /// Sign the transaction using the active account.
-      /// If no active account has been set with SelectAccount, return [ErrCode](#land.gno.gnonative.v1.ErrCode).ErrNoActiveAccount.
+      /// Sign the transaction using the account with the given address.
+      /// If there is no activated account with the given address, return [ErrCode](#land.gno.gnonative.v1.ErrCode).ErrNoActiveAccount.
       /// If the password is wrong, return [ErrCode](#land.gno.gnonative.v1.ErrCode).ErrDecryptionFailed.
       /// </summary>
       /// <param name="request">The request received from the client.</param>
@@ -259,8 +259,8 @@ namespace Land.Gno.GnokeyMobile.V1 {
         return CallInvoker.AsyncUnaryCall(__Method_ListKeyInfo, null, options, request);
       }
       /// <summary>
-      /// Sign the transaction using the active account.
-      /// If no active account has been set with SelectAccount, return [ErrCode](#land.gno.gnonative.v1.ErrCode).ErrNoActiveAccount.
+      /// Sign the transaction using the account with the given address.
+      /// If there is no activated account with the given address, return [ErrCode](#land.gno.gnonative.v1.ErrCode).ErrNoActiveAccount.
       /// If the password is wrong, return [ErrCode](#land.gno.gnonative.v1.ErrCode).ErrDecryptionFailed.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
@@ -274,8 +274,8 @@ namespace Land.Gno.GnokeyMobile.V1 {
         return SignTx(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
       /// <summary>
-      /// Sign the transaction using the active account.
-      /// If no active account has been set with SelectAccount, return [ErrCode](#land.gno.gnonative.v1.ErrCode).ErrNoActiveAccount.
+      /// Sign the transaction using the account with the given address.
+      /// If there is no activated account with the given address, return [ErrCode](#land.gno.gnonative.v1.ErrCode).ErrNoActiveAccount.
       /// If the password is wrong, return [ErrCode](#land.gno.gnonative.v1.ErrCode).ErrDecryptionFailed.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
@@ -287,8 +287,8 @@ namespace Land.Gno.GnokeyMobile.V1 {
         return CallInvoker.BlockingUnaryCall(__Method_SignTx, null, options, request);
       }
       /// <summary>
-      /// Sign the transaction using the active account.
-      /// If no active account has been set with SelectAccount, return [ErrCode](#land.gno.gnonative.v1.ErrCode).ErrNoActiveAccount.
+      /// Sign the transaction using the account with the given address.
+      /// If there is no activated account with the given address, return [ErrCode](#land.gno.gnonative.v1.ErrCode).ErrNoActiveAccount.
       /// If the password is wrong, return [ErrCode](#land.gno.gnonative.v1.ErrCode).ErrDecryptionFailed.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
@@ -302,8 +302,8 @@ namespace Land.Gno.GnokeyMobile.V1 {
         return SignTxAsync(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
       /// <summary>
-      /// Sign the transaction using the active account.
-      /// If no active account has been set with SelectAccount, return [ErrCode](#land.gno.gnonative.v1.ErrCode).ErrNoActiveAccount.
+      /// Sign the transaction using the account with the given address.
+      /// If there is no activated account with the given address, return [ErrCode](#land.gno.gnonative.v1.ErrCode).ErrNoActiveAccount.
       /// If the password is wrong, return [ErrCode](#land.gno.gnonative.v1.ErrCode).ErrDecryptionFailed.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>

--- a/api/gen/es/gnokey_mobile_rpc_connect.d.ts
+++ b/api/gen/es/gnokey_mobile_rpc_connect.d.ts
@@ -37,8 +37,8 @@ export declare const GnokeyMobileService: {
       readonly kind: MethodKind.Unary,
     },
     /**
-     * Sign the transaction using the active account.
-     * If no active account has been set with SelectAccount, return [ErrCode](#land.gno.gnonative.v1.ErrCode).ErrNoActiveAccount.
+     * Sign the transaction using the account with the given address.
+     * If there is no activated account with the given address, return [ErrCode](#land.gno.gnonative.v1.ErrCode).ErrNoActiveAccount.
      * If the password is wrong, return [ErrCode](#land.gno.gnonative.v1.ErrCode).ErrDecryptionFailed.
      *
      * @generated from rpc land.gno.gnokey_mobile.v1.GnokeyMobileService.SignTx

--- a/api/gen/es/gnokey_mobile_rpc_connect.js
+++ b/api/gen/es/gnokey_mobile_rpc_connect.js
@@ -37,8 +37,8 @@ export const GnokeyMobileService = {
       kind: MethodKind.Unary,
     },
     /**
-     * Sign the transaction using the active account.
-     * If no active account has been set with SelectAccount, return [ErrCode](#land.gno.gnonative.v1.ErrCode).ErrNoActiveAccount.
+     * Sign the transaction using the account with the given address.
+     * If there is no activated account with the given address, return [ErrCode](#land.gno.gnonative.v1.ErrCode).ErrNoActiveAccount.
      * If the password is wrong, return [ErrCode](#land.gno.gnonative.v1.ErrCode).ErrDecryptionFailed.
      *
      * @generated from rpc land.gno.gnokey_mobile.v1.GnokeyMobileService.SignTx

--- a/api/gen/es/gnokey_mobile_rpc_pb.d.ts
+++ b/api/gen/es/gnokey_mobile_rpc_pb.d.ts
@@ -134,8 +134,8 @@ export declare const GnokeyMobileService: GenService<{
     output: typeof ListKeyInfoResponseSchema;
   },
   /**
-   * Sign the transaction using the active account.
-   * If no active account has been set with SelectAccount, return [ErrCode](#land.gno.gnonative.v1.ErrCode).ErrNoActiveAccount.
+   * Sign the transaction using the account with the given address.
+   * If there is no activated account with the given address, return [ErrCode](#land.gno.gnonative.v1.ErrCode).ErrNoActiveAccount.
    * If the password is wrong, return [ErrCode](#land.gno.gnonative.v1.ErrCode).ErrDecryptionFailed.
    *
    * @generated from rpc land.gno.gnokey_mobile.v1.GnokeyMobileService.SignTx

--- a/api/gen/go/_goconnect/gnokey_mobile_rpc.connect.go
+++ b/api/gen/go/_goconnect/gnokey_mobile_rpc.connect.go
@@ -60,8 +60,8 @@ type GnokeyMobileServiceClient interface {
 	GetRemote(context.Context, *connect.Request[_go1.GetRemoteRequest]) (*connect.Response[_go1.GetRemoteResponse], error)
 	// Get the information for all keys in the keybase
 	ListKeyInfo(context.Context, *connect.Request[_go1.ListKeyInfoRequest]) (*connect.Response[_go1.ListKeyInfoResponse], error)
-	// Sign the transaction using the active account.
-	// If no active account has been set with SelectAccount, return [ErrCode](#land.gno.gnonative.v1.ErrCode).ErrNoActiveAccount.
+	// Sign the transaction using the account with the given address.
+	// If there is no activated account with the given address, return [ErrCode](#land.gno.gnonative.v1.ErrCode).ErrNoActiveAccount.
 	// If the password is wrong, return [ErrCode](#land.gno.gnonative.v1.ErrCode).ErrDecryptionFailed.
 	SignTx(context.Context, *connect.Request[_go1.SignTxRequest]) (*connect.Response[_go1.SignTxResponse], error)
 }
@@ -127,8 +127,8 @@ type GnokeyMobileServiceHandler interface {
 	GetRemote(context.Context, *connect.Request[_go1.GetRemoteRequest]) (*connect.Response[_go1.GetRemoteResponse], error)
 	// Get the information for all keys in the keybase
 	ListKeyInfo(context.Context, *connect.Request[_go1.ListKeyInfoRequest]) (*connect.Response[_go1.ListKeyInfoResponse], error)
-	// Sign the transaction using the active account.
-	// If no active account has been set with SelectAccount, return [ErrCode](#land.gno.gnonative.v1.ErrCode).ErrNoActiveAccount.
+	// Sign the transaction using the account with the given address.
+	// If there is no activated account with the given address, return [ErrCode](#land.gno.gnonative.v1.ErrCode).ErrNoActiveAccount.
 	// If the password is wrong, return [ErrCode](#land.gno.gnonative.v1.ErrCode).ErrDecryptionFailed.
 	SignTx(context.Context, *connect.Request[_go1.SignTxRequest]) (*connect.Response[_go1.SignTxResponse], error)
 }

--- a/api/gnokey_mobile_rpc.proto
+++ b/api/gnokey_mobile_rpc.proto
@@ -15,8 +15,8 @@ service GnokeyMobileService {
   // Get the information for all keys in the keybase
   rpc ListKeyInfo(land.gno.gnonative.v1.ListKeyInfoRequest) returns (land.gno.gnonative.v1.ListKeyInfoResponse);
 
-  // Sign the transaction using the active account.
-  // If no active account has been set with SelectAccount, return [ErrCode](#land.gno.gnonative.v1.ErrCode).ErrNoActiveAccount.
+  // Sign the transaction using the account with the given address.
+  // If there is no activated account with the given address, return [ErrCode](#land.gno.gnonative.v1.ErrCode).ErrNoActiveAccount.
   // If the password is wrong, return [ErrCode](#land.gno.gnonative.v1.ErrCode).ErrDecryptionFailed.
   rpc SignTx(land.gno.gnonative.v1.SignTxRequest) returns (land.gno.gnonative.v1.SignTxResponse);
 }

--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,8 @@ require (
 	connectrpc.com/connect v1.16.2
 	connectrpc.com/grpchealth v1.3.0
 	connectrpc.com/grpcreflect v1.2.0
-	github.com/gnolang/gno v0.1.1
-	github.com/gnolang/gnonative v1.5.1-0.20240814142433-69d4f3e915b3
+	github.com/gnolang/gno v0.1.2-0.20240826090356-651f5aac3706
+	github.com/gnolang/gnonative v1.7.3-0.20240903142546-1a678ad07ce4
 	github.com/peterbourgon/ff/v3 v3.4.0
 	github.com/pkg/errors v0.9.1
 	github.com/rs/cors v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,6 @@ github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHqu
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
-github.com/gnolang/gnonative v1.7.2 h1:gZffTVfTk0ABebdwlWK6FWux7fkiWJADymv6QRchWzE=
-github.com/gnolang/gnonative v1.7.2/go.mod h1:M8AhlFKOWmJrgS2BWMcMu4h+1rFyMzLqBm5Ow3T9YMA=
 github.com/gnolang/gnonative v1.7.3-0.20240903142546-1a678ad07ce4 h1:9E3lEHVwNA8e5SAC0An3x0fWQ2aOu0CCzrQe1qPFhbs=
 github.com/gnolang/gnonative v1.7.3-0.20240903142546-1a678ad07ce4/go.mod h1:M8AhlFKOWmJrgS2BWMcMu4h+1rFyMzLqBm5Ow3T9YMA=
 github.com/gnolang/overflow v0.0.0-20170615021017-4d914c927216 h1:GKvsK3oLWG9B1GL7WP/VqwM6C92j5tIvB844oggL9Lk=

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,10 @@ github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHqu
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
-github.com/gnolang/gnonative v1.5.1-0.20240814142433-69d4f3e915b3 h1:lwRzsEYnrKRRFkwjNvG/ocexS+o9HHy1j3QeBbRxf4o=
-github.com/gnolang/gnonative v1.5.1-0.20240814142433-69d4f3e915b3/go.mod h1:i8Zh8GqixyzCq5ZKaitmgTCaDaMozSUgjk4XtRiguzw=
+github.com/gnolang/gnonative v1.7.2 h1:gZffTVfTk0ABebdwlWK6FWux7fkiWJADymv6QRchWzE=
+github.com/gnolang/gnonative v1.7.2/go.mod h1:M8AhlFKOWmJrgS2BWMcMu4h+1rFyMzLqBm5Ow3T9YMA=
+github.com/gnolang/gnonative v1.7.3-0.20240903142546-1a678ad07ce4 h1:9E3lEHVwNA8e5SAC0An3x0fWQ2aOu0CCzrQe1qPFhbs=
+github.com/gnolang/gnonative v1.7.3-0.20240903142546-1a678ad07ce4/go.mod h1:M8AhlFKOWmJrgS2BWMcMu4h+1rFyMzLqBm5Ow3T9YMA=
 github.com/gnolang/overflow v0.0.0-20170615021017-4d914c927216 h1:GKvsK3oLWG9B1GL7WP/VqwM6C92j5tIvB844oggL9Lk=
 github.com/gnolang/overflow v0.0.0-20170615021017-4d914c927216/go.mod h1:xJhtEL7ahjM1WJipt89gel8tHzfIl/LyMY+lCYh38d8=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/service/api.go
+++ b/service/api.go
@@ -49,7 +49,7 @@ func (s *gnokeyMobileService) SignTx(ctx context.Context, req *connect.Request[g
 		return nil, err
 	}
 
-	signedTx, err := s.gnoNativeService.ClientSignTx(tx, req.Msg.AccountNumber, req.Msg.SequenceNumber)
+	signedTx, err := s.gnoNativeService.ClientSignTx(tx, req.Msg.Address, req.Msg.AccountNumber, req.Msg.SequenceNumber)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
We need to update to use the latest gnonative changes in PR https://github.com/gnolang/gnonative/pull/172 . This PR has two commits:

1. In go.mod, use the latest gnonative. In the call to `gnoNativeService.ClientSignTx`, add the address argument, [the same as in gnonative](https://github.com/gnolang/gnonative/blob/1a678ad07ce49be47859c2e36cd73f5a93b55fa0/service/api.go#L814).
2. In gnokey_mobile_rpc.proto, update the doc comment for `SignTx` to be [the same as in gnonative](https://github.com/gnolang/gnonative/blob/1a678ad07ce49be47859c2e36cd73f5a93b55fa0/api/rpc.proto#L157-L160). Run `make regenerate`.

(When these changes are merged, we will be able to update the gnonative expo module.)