### PR TITLE
fix: In registerAccount, use Coin for the send amount

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -13,7 +13,7 @@
         "@bufbuild/protobuf": "^1.6.0",
         "@connectrpc/connect": "^1.2.1",
         "@connectrpc/connect-web": "^1.2.1",
-        "@gnolang/gnonative": "^3.0.4",
+        "@gnolang/gnonative": "^4.0.0",
         "@reduxjs/toolkit": "^2.1.0",
         "date-fns": "^3.6.0",
         "expo": "~51.0.36",
@@ -2323,25 +2323,25 @@
       }
     },
     "node_modules/@buf/gnolang_gnonative.bufbuild_es": {
-      "version": "1.8.0-20241017082556-947364df1499.3",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/gnolang_gnonative.bufbuild_es/-/gnolang_gnonative.bufbuild_es-1.8.0-20241017082556-947364df1499.3.tgz",
+      "version": "1.8.0-20241030100906-5ceb62413f58.3",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/gnolang_gnonative.bufbuild_es/-/gnolang_gnonative.bufbuild_es-1.8.0-20241030100906-5ceb62413f58.3.tgz",
       "peerDependencies": {
         "@bufbuild/protobuf": "^1.8.0"
       }
     },
     "node_modules/@buf/gnolang_gnonative.connectrpc_es": {
-      "version": "1.4.0-20241017082556-947364df1499.3",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/gnolang_gnonative.connectrpc_es/-/gnolang_gnonative.connectrpc_es-1.4.0-20241017082556-947364df1499.3.tgz",
+      "version": "1.4.0-20241030100906-5ceb62413f58.3",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/gnolang_gnonative.connectrpc_es/-/gnolang_gnonative.connectrpc_es-1.4.0-20241030100906-5ceb62413f58.3.tgz",
       "dependencies": {
-        "@buf/gnolang_gnonative.bufbuild_es": "1.7.2-20241017082556-947364df1499.2"
+        "@buf/gnolang_gnonative.bufbuild_es": "1.7.2-20241030100906-5ceb62413f58.2"
       },
       "peerDependencies": {
         "@connectrpc/connect": "^1.4.0"
       }
     },
     "node_modules/@buf/gnolang_gnonative.connectrpc_es/node_modules/@buf/gnolang_gnonative.bufbuild_es": {
-      "version": "1.7.2-20241017082556-947364df1499.2",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/gnolang_gnonative.bufbuild_es/-/gnolang_gnonative.bufbuild_es-1.7.2-20241017082556-947364df1499.2.tgz",
+      "version": "1.7.2-20241030100906-5ceb62413f58.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/gnolang_gnonative.bufbuild_es/-/gnolang_gnonative.bufbuild_es-1.7.2-20241030100906-5ceb62413f58.2.tgz",
       "peerDependencies": {
         "@bufbuild/protobuf": "^1.7.2"
       }
@@ -3580,12 +3580,12 @@
       }
     },
     "node_modules/@gnolang/gnonative": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@gnolang/gnonative/-/gnonative-3.0.4.tgz",
-      "integrity": "sha512-yb5svyBJ8eaiK4+wU7VL/cwjQmcRuKzEQkVpe9C4RmZEKjWYAA+WTD98CIi7kuM4lhHCNRQ8OAvYVsT7oQ2cVQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@gnolang/gnonative/-/gnonative-4.0.0.tgz",
+      "integrity": "sha512-bjx6ahGDeWZshQsysFVIBj1Kte7+tVQUjqH3xhadshgzkhbD0wdX0pFbNSnczlL0POMAJT+6wkGKG5uZhNTOOw==",
       "dependencies": {
-        "@buf/gnolang_gnonative.bufbuild_es": "^1.8.0-20241017082556-947364df1499.3",
-        "@buf/gnolang_gnonative.connectrpc_es": "^1.4.0-20241017082556-947364df1499.3",
+        "@buf/gnolang_gnonative.bufbuild_es": "^1.8.0-20241030100906-5ceb62413f58.3",
+        "@buf/gnolang_gnonative.connectrpc_es": "^1.4.0-20241030100906-5ceb62413f58.3",
         "@bufbuild/protobuf": "^1.8.0",
         "@connectrpc/connect": "^1.4.0",
         "@connectrpc/connect-web": "^1.4.0",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -16,7 +16,7 @@
     "@bufbuild/protobuf": "^1.6.0",
     "@connectrpc/connect": "^1.2.1",
     "@connectrpc/connect-web": "^1.2.1",
-    "@gnolang/gnonative": "^3.0.4",
+    "@gnolang/gnonative": "^4.0.0",
     "@reduxjs/toolkit": "^2.1.0",
     "date-fns": "^3.6.0",
     "expo": "~51.0.36",

--- a/mobile/redux/features/signupSlice.ts
+++ b/mobile/redux/features/signupSlice.ts
@@ -3,6 +3,7 @@ import { GnoNativeApi, KeyInfo } from "@gnolang/gnonative";
 import { ThunkExtra } from "@/src/providers/redux-provider";
 import { Alert } from "react-native";
 import { User } from "@/types";
+import { Coin } from '@buf/gnolang_gnonative.bufbuild_es/gnonativetypes_pb';
 
 export enum SignUpState {
   user_exists_on_blockchain_and_local_storage = 'user_exists_on_blockchain_and_local_storage',
@@ -215,7 +216,7 @@ const registerAccount = async (gnonative: GnoNativeApi, account: KeyInfo) => {
   try {
     const gasFee = "10000000ugnot";
     const gasWanted = BigInt(20000000);
-    const send = "200000000ugnot";
+    const send = [new Coin({denom: "ugnot", amount: BigInt(200000000)})];
     const args: Array<string> = ["", account.name, "Profile description"];
     for await (const response of await gnonative.call("gno.land/r/demo/users", "Register", args, gasFee, gasWanted, account.address, send)) {
       console.log("response: ", JSON.stringify(response));


### PR DESCRIPTION
Gnonative PR https://github.com/gnolang/gnonative/pull/193 changes the send amount in `call` to use an array of `Coin` for the send amount. (This is to match the core go code API.) This PR updates to the latest gnonative NPM module and updates `registerAccount` to use an array of `Coin` for the send amount in the call to "Register".