### PR TITLE
fix: cancellation of transaction requests without a callback

### DIFF
--- a/mobile/app/(app)/tosign/index.tsx
+++ b/mobile/app/(app)/tosign/index.tsx
@@ -50,8 +50,11 @@ export default function Page() {
 
     const onCancel = () => {
         dispatch(clearLinking());
-        // callback to requester
-        Linking.openURL(`${callback}?status=cancelled`);
+        if (callback) {
+            Linking.openURL(`${callback}?status=cancelled`); // callback to requester
+        } else {
+            router.push("/home");
+        }
     }
 
     return (

--- a/mobile/redux/features/linkingSlice.ts
+++ b/mobile/redux/features/linkingSlice.ts
@@ -82,6 +82,7 @@ interface SetLinkResponse {
 }
 
 export const setLinkingData = createAsyncThunk<SetLinkResponse, Linking.ParsedURL, ThunkExtra>("linking/setLinkingData", async (parsedURL, thunkAPI) => {
+  console.log('deep link received', parsedURL);
 
   const queryParams = parsedURL.queryParams
   const gnonative = thunkAPI.extra.gnonative as GnoNativeApi;


### PR DESCRIPTION
Ensure that canceling a transaction request redirects to the home page if no callback is provided. Additionally, log the received deep link for better debugging.