### PR TITLE
chore: README: Update doc for inter-app communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+
+## Inter-app communication
+
+The Gnokey Mobile app uses `expo-linking` to exchange data with your app such as dSocial.
+This way, your app can sign in or sign a transaction using the Gnokey Mobile app.
+
+### Sign in
+
+Example of dSocial asking for sign in:
+```
+land.gno.gnokey://tosignin?callback=tech.berty.dsocial%3A%2F%2Fsignin-callback
+```
+- Base url: `land.gno.gnokey://tosignin`
+- Parameters:
+  - callback: the URL that Gnokey Mobile will call after the user selects the account.
+
+
+### Sign a transaction
+Example of dSocial asking Gnokey Mobile to sign a transaction:
+```
+land.gno.gnokey://tosign?tx=%257B%2522msg%2522%253A%255B%257B%2522%2540type%2522%253A%2522%252Fvm.m_call%2522%252C%2522caller%2522%253A%2522g1gl0hrpuegawx6pv24xjq8jjmufzp5r5mnn896w%2522%252C%2522send%2522%253A%2522%2522%252C%2522pkg_path%2522%253A%2522gno.land%252Fr%252Fberty%252Fsocial%2522%252C%2522func%2522%253A%2522PostMessage%2522%252C%2522args%2522%253A%255B%2522Test%25203%2522%255D%257D%255D%252C%2522fee%2522%253A%257B%2522gas_wanted%2522%253A%252210000000%2522%252C%2522gas_fee%2522%253A%25221000000ugnot%2522%257D%252C%2522signatures%2522%253Anull%252C%2522memo%2522%253A%2522%2522%257D&address=g1gl0hrpuegawx6pv24xjq8jjmufzp5r5mnn896w&client_name=dSocial&reason=Post%20a%20message&callback=tech.berty.dsocial%253A%252F%252Fpost
+```
+
+- Base url: `land.gno.gnokey://tosign`
+- Parameters (as usual, values are percent-escaped with `encodeURIComponent`):
+  - tx: the json result of `gnonative.makeCallTx(...)`
+  - address: bech32 address of whoever you want to sign the transaction.
+  - client_name: the name of the app that is calling the Gnokey Mobile app. It will be displayed to the user.
+  - reason: the reason behind this action. It will be displayed to the user.
+  - callback: the URL that Gnokey Mobile will call after signing the tx.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Example of dSocial asking for sign in:
 ```
 land.gno.gnokey://tosignin?callback=tech.berty.dsocial%3A%2F%2Fsignin-callback
 ```
-- Base url: `land.gno.gnokey://tosignin`
+- Base URL: `land.gno.gnokey://tosignin`
 - Parameters:
   - callback: the URL that Gnokey Mobile will call after the user selects the account.
 
@@ -18,17 +18,25 @@ land.gno.gnokey://tosignin?callback=tech.berty.dsocial%3A%2F%2Fsignin-callback
 ### Sign a transaction
 Example of dSocial asking Gnokey Mobile to sign a transaction (with added newlines for clarity):
 ```
-land.gno.gnokey://tosign?tx=%257B%2522msg%2522%253A%255B%257B%2522%2540type%2522%253A%2522%252Fvm.m_call%2522%252C%2522caller%2522%253A%2522g1gl0hrpuegawx6pv24xjq8jjmufzp5r5mnn896w%2522%252C%2522send%2522%253A%2522%2522%252C%2522pkg_path%2522%253A%2522gno.land%252Fr%252Fberty%252Fsocial%2522%252C%2522func%2522%253A%2522PostMessage%2522%252C%2522args%2522%253A%255B%2522Test%25203%2522%255D%257D%255D%252C%2522fee%2522%253A%257B%2522gas_wanted%2522%253A%252210000000%2522%252C%2522gas_fee%2522%253A%25221000000ugnot%2522%257D%252C%2522signatures%2522%253Anull%252C%2522memo%2522%253A%2522%2522%257D
-&address=g1gl0hrpuegawx6pv24xjq8jjmufzp5r5mnn896w
+land.gno.gnokey://tosign?tx=%7B%22msg%22%3A%5B%7B%22%40type%22%3A%22%2Fvm.m_call%22%2C%22caller%22%3A%22g19h0el2p7z8thtqy4rze0n6en94xux9fazf0rp3%22%2C%22send%22%3A%22%22%2C%22pkg_path%22%3A%22gno.land%2Fr%2Fberty%2Fsocial%22%2C%22func%22%3A%22PostMessage%22%2C%22args%22%3A%5B%22Hello%22%5D%7D%5D%2C%22fee%22%3A%7B%22gas_wanted%22%3A%2210000000%22%2C%22gas_fee%22%3A%221000000ugnot%22%7D%2C%22signatures%22%3Anull%2C%22memo%22%3A%22%22%7D
+&address=g19h0el2p7z8thtqy4rze0n6en94xux9fazf0rp3
 &client_name=dSocial
 &reason=Post%20a%20message
-&callback=tech.berty.dsocial%253A%252F%252Fpost
+&callback=tech.berty.dsocial%3A%2F%2Fpost
 ```
 
-- Base url: `land.gno.gnokey://tosign`
-- Parameters (as usual, values are percent-escaped with `encodeURIComponent`):
+- Base URL: `land.gno.gnokey://tosign`
+- Parameters (values should be percent-escaped with `encodeURIComponent`):
   - tx: the json result of `gnonative.makeCallTx(...)`
   - address: bech32 address of whoever you want to sign the transaction.
   - client_name: the name of the app that is calling the Gnokey Mobile app. It will be displayed to the user.
   - reason: the reason behind this action. It will be displayed to the user.
   - callback: the URL that Gnokey Mobile will call after signing the tx.
+
+Example response:
+```
+tech.berty.dsocial://post?tx=%7B%22msg%22%3A%5B%7B%22%40type%22%3A%22%2Fvm.m_call%22%2C%22caller%22%3A%22g19h0el2p7z8thtqy4rze0n6en94xux9fazf0rp3%22%2C%22send%22%3A%22%22%2C%22pkg_path%22%3A%22gno.land%2Fr%2Fberty%2Fsocial%22%2C%22func%22%3A%22PostMessage%22%2C%22args%22%3A%5B%22Hello%22%5D%7D%5D%2C%22fee%22%3A%7B%22gas_wanted%22%3A%2210000000%22%2C%22gas_fee%22%3A%221000000ugnot%22%7D%2C%22signatures%22%3A%5B%7B%22pub_key%22%3A%7B%22%40type%22%3A%22%2Ftm.PubKeySecp256k1%22%2C%22value%22%3A%22A6YT26ehhjN7YXx%2BLZza2Gp31yP5bJ6INfeGf%2FrumHFR%22%7D%2C%22signature%22%3A%226KAdOO2YXyZmp8ehiin6Rsz%2Bhxu30W0pB00%2Bv1xnpzMSZ%2BBIVdZbo1gdlVGp0E24ZLRyPrsKtb0Q4%2FkdD57qGg%3D%3D%22%7D%5D%2C%22memo%22%3A%22%22%7D
+```
+- Base URL: The `callback` from the request. In this case, `tech.berty.dsocial://post`
+- Parameters (values are percent-escaped, to be decoded with `decodeURIComponent`):
+  - tx: the signed transaction json to pass to `gnonative.broadcastTxCommit(...)`

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This way, your app can sign in or sign a transaction using the Gnokey Mobile app
 
 ### Sign in
 
-Example of dSocial asking for sign in:
+Example of a dSocial request for sign in:
 ```
 land.gno.gnokey://tosignin?callback=tech.berty.dsocial%3A%2F%2Fsignin-callback
 ```
@@ -16,7 +16,7 @@ land.gno.gnokey://tosignin?callback=tech.berty.dsocial%3A%2F%2Fsignin-callback
 
 
 ### Sign a transaction
-Example of dSocial asking Gnokey Mobile to sign a transaction (with added newlines for clarity):
+Example of a dSocial request to Gnokey Mobile to sign a transaction (with added newlines for clarity):
 ```
 land.gno.gnokey://tosign?tx=%7B%22msg%22%3A%5B%7B%22%40type%22%3A%22%2Fvm.m_call%22%2C%22caller%22%3A%22g19h0el2p7z8thtqy4rze0n6en94xux9fazf0rp3%22%2C%22send%22%3A%22%22%2C%22pkg_path%22%3A%22gno.land%2Fr%2Fberty%2Fsocial%22%2C%22func%22%3A%22PostMessage%22%2C%22args%22%3A%5B%22Hello%22%5D%7D%5D%2C%22fee%22%3A%7B%22gas_wanted%22%3A%2210000000%22%2C%22gas_fee%22%3A%221000000ugnot%22%7D%2C%22signatures%22%3Anull%2C%22memo%22%3A%22%22%7D
 &address=g19h0el2p7z8thtqy4rze0n6en94xux9fazf0rp3
@@ -40,3 +40,18 @@ tech.berty.dsocial://post?tx=%7B%22msg%22%3A%5B%7B%22%40type%22%3A%22%2Fvm.m_cal
 - Base URL: The `callback` from the request. In this case, `tech.berty.dsocial://post`
 - Parameters (values are percent-escaped, to be decoded with `decodeURIComponent`):
   - tx: the signed transaction json to pass to `gnonative.broadcastTxCommit(...)`
+
+### Testing on iOS simulator
+
+If you are using `make ios` to run Gnokey Mobile in the iOS simulator, you can send a test transaction simply by
+pasting the request URL into Safari in the simulator. This will open Gnokey Mobile where you can approve. The
+response URL is printed in the terminal running `make ios` .
+
+### Testing on Android simulator
+
+If you are using `make android` to run Gnokey Mobile in the Android simulator, you can use `adb` to send the URL
+of a test transaction. You must change each `&` to `\&` . The following example will open Gnokey Mobile where you can approve. The
+response URL is printed in the terminal running `make android` .
+```
+adb shell am start -a android.intent.action.VIEW -d "land.gno.gnokey://tosign?tx=%7B%22msg%22%3A%5B%7B%22%40type%22%3A%22%2Fvm.m_call%22%2C%22caller%22%3A%22g19h0el2p7z8thtqy4rze0n6en94xux9fazf0rp3%22%2C%22send%22%3A%22%22%2C%22pkg_path%22%3A%22gno.land%2Fr%2Fberty%2Fsocial%22%2C%22func%22%3A%22PostMessage%22%2C%22args%22%3A%5B%22Hello%22%5D%7D%5D%2C%22fee%22%3A%7B%22gas_wanted%22%3A%2210000000%22%2C%22gas_fee%22%3A%221000000ugnot%22%7D%2C%22signatures%22%3Anull%2C%22memo%22%3A%22%22%7D\&address=g19h0el2p7z8thtqy4rze0n6en94xux9fazf0rp3\&client_name=dSocial\&reason=Post%20a%20message\&callback=tech.berty.dsocial%3A%2F%2Fpost"
+```

--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ land.gno.gnokey://tosignin?callback=tech.berty.dsocial%3A%2F%2Fsignin-callback
 - Parameters:
   - callback: the URL that Gnokey Mobile will call after the user selects the account.
 
+Example response:
+```
+tech.berty.dsocial://signin-callback?address=g19h0el2p7z8thtqy4rze0n6en94xux9fazf0rp3&cachekill=1732030818190
+```
+- Base URL: The `callback` from the request. In this case, `tech.berty.dsocial://signin-callback`
+- Parameters:
+  - address: the address of the selected user
+  - cachekill: For testing. Ignore this.
 
 ### Sign a transaction
 Example of a dSocial request to Gnokey Mobile to sign a transaction (with added newlines for clarity):

--- a/README.md
+++ b/README.md
@@ -16,9 +16,13 @@ land.gno.gnokey://tosignin?callback=tech.berty.dsocial%3A%2F%2Fsignin-callback
 
 
 ### Sign a transaction
-Example of dSocial asking Gnokey Mobile to sign a transaction:
+Example of dSocial asking Gnokey Mobile to sign a transaction (with added newlines for clarity):
 ```
-land.gno.gnokey://tosign?tx=%257B%2522msg%2522%253A%255B%257B%2522%2540type%2522%253A%2522%252Fvm.m_call%2522%252C%2522caller%2522%253A%2522g1gl0hrpuegawx6pv24xjq8jjmufzp5r5mnn896w%2522%252C%2522send%2522%253A%2522%2522%252C%2522pkg_path%2522%253A%2522gno.land%252Fr%252Fberty%252Fsocial%2522%252C%2522func%2522%253A%2522PostMessage%2522%252C%2522args%2522%253A%255B%2522Test%25203%2522%255D%257D%255D%252C%2522fee%2522%253A%257B%2522gas_wanted%2522%253A%252210000000%2522%252C%2522gas_fee%2522%253A%25221000000ugnot%2522%257D%252C%2522signatures%2522%253Anull%252C%2522memo%2522%253A%2522%2522%257D&address=g1gl0hrpuegawx6pv24xjq8jjmufzp5r5mnn896w&client_name=dSocial&reason=Post%20a%20message&callback=tech.berty.dsocial%253A%252F%252Fpost
+land.gno.gnokey://tosign?tx=%257B%2522msg%2522%253A%255B%257B%2522%2540type%2522%253A%2522%252Fvm.m_call%2522%252C%2522caller%2522%253A%2522g1gl0hrpuegawx6pv24xjq8jjmufzp5r5mnn896w%2522%252C%2522send%2522%253A%2522%2522%252C%2522pkg_path%2522%253A%2522gno.land%252Fr%252Fberty%252Fsocial%2522%252C%2522func%2522%253A%2522PostMessage%2522%252C%2522args%2522%253A%255B%2522Test%25203%2522%255D%257D%255D%252C%2522fee%2522%253A%257B%2522gas_wanted%2522%253A%252210000000%2522%252C%2522gas_fee%2522%253A%25221000000ugnot%2522%257D%252C%2522signatures%2522%253Anull%252C%2522memo%2522%253A%2522%2522%257D
+&address=g1gl0hrpuegawx6pv24xjq8jjmufzp5r5mnn896w
+&client_name=dSocial
+&reason=Post%20a%20message
+&callback=tech.berty.dsocial%253A%252F%252Fpost
 ```
 
 - Base url: `land.gno.gnokey://tosign`

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -125,34 +125,3 @@ make android
 # to start Metro Bundler:
 make start
 ```
-
-## Inter App communication
-
-dSocial and Gnokey mobile app are using `expo-linking` to exchange data.
-So that way you can signin or sign a transaction using Gnokey mobile app.
-
-### Sign in
-
-Example of dSocial asking for sign in
-```
-land.gno.gnokey://tosignin?callback=tech.berty.dsocial%3A%2F%2Fsignin-callback
-```
-- Base url: `land.gno.gnokey://tosignin`
-- Parameters:
-  - callback: the url that Gnokey mobile will call after the user selecting the account.
-
-
-### Sign a transaction
-Example of dSocial asking Gnokey Mobile to sign a transaction:
-```
-land.gno.gnokey://tosign?tx=%257B%2522msg%2522%253A%255B%257B%2522%2540type%2522%253A%2522%252Fvm.m_call%2522%252C%2522caller%2522%253A%2522g1gl0hrpuegawx6pv24xjq8jjmufzp5r5mnn896w%2522%252C%2522send%2522%253A%2522%2522%252C%2522pkg_path%2522%253A%2522gno.land%252Fr%252Fberty%252Fsocial%2522%252C%2522func%2522%253A%2522PostMessage%2522%252C%2522args%2522%253A%255B%2522Test%25203%2522%255D%257D%255D%252C%2522fee%2522%253A%257B%2522gas_wanted%2522%253A%252210000000%2522%252C%2522gas_fee%2522%253A%25221000000ugnot%2522%257D%252C%2522signatures%2522%253Anull%252C%2522memo%2522%253A%2522%2522%257D&address=g1gl0hrpuegawx6pv24xjq8jjmufzp5r5mnn896w&client_name=dSocial&reason=Post%20a%20message&callback=tech.berty.dsocial%253A%252F%252Fpost
-```
-
-- Base url: `land.gno.gnokey://tosign`
-- Parameters:
-  - tx: the json result of `gnonative.makeCallTx(...)`
-  - address: bech32 address of whoever you want to sign the transaction.
-  - client_name: the name of the application that is calling the Gnokey mobile application. It will be displayed to the user.
-  - reason: the reason behind this action. It will be displayed to the user.
-  - callback: the callback URL that will be called from Gnokey mobile after signing the tx.
-

--- a/mobile/app/(app)/tosign/index.tsx
+++ b/mobile/app/(app)/tosign/index.tsx
@@ -43,7 +43,9 @@ export default function Page() {
         const signedTx = await dispatch(signTx({ keyInfo })).unwrap();
 
         const path = callback ? callback : 'tech.berty.dsocial://post';
-        Linking.openURL(`${path}?tx=${encodeURIComponent(signedTx.signedTxJson)}`);
+        const url = `${path}?tx=${encodeURIComponent(signedTx.signedTxJson)}`;
+        console.log("response URL " + url);
+        Linking.openURL(url);
 
         router.push("/home")
     }


### PR DESCRIPTION
This PR updates the doc for inter-app communication.

* Move the section for inter-app communication from mobile/README.md to the main README.
* Add example responses.
* Add section for sending a test URL.
* In the tosign response, print the response URL to the console. This is needed when sending a test URL.