### PR TITLE
feat: use the latest users realm

### DIFF
--- a/mobile/app/(app)/add-key/index.tsx
+++ b/mobile/app/(app)/add-key/index.tsx
@@ -103,8 +103,8 @@ export default function Page() {
       return
     }
 
-    // Use the same regex and error message as r/demo/users
-    if (!keyName.match(/^[a-z]+[_a-z0-9]{5,16}$/)) {
+    // Use the same regex and error message as r/gnoland/users/v1
+    if (!keyName.match("^[a-z]{3}[_a-z0-9]{0,14}[0-9]{3}$")) {
       setError("Account name must be at least 6 characters, lowercase alphanumeric with underscore");
       return;
     }

--- a/mobile/app/(app)/tosign/index.tsx
+++ b/mobile/app/(app)/tosign/index.tsx
@@ -36,7 +36,7 @@ export default function Page() {
             gnonative.setChainID(chainId);
             gnonative.setRemote(remote);
 
-            const accountNameStr = await gnonative.qEval("gno.land/r/demo/users", `GetUserByAddress("${bech32Address}").Name`);
+            const accountNameStr = await gnonative.qEval("gno.land/r/sys/users", `ResolveAddress("${bech32Address}").Name()`);
             setAccountName(accountNameStr);
         })();
     }, [bech32Address]);

--- a/mobile/views/chain-select/index.tsx
+++ b/mobile/views/chain-select/index.tsx
@@ -19,7 +19,7 @@ const ChainSelectView = () => {
     return (
         <View style={{ borderColor: 'black', borderWidth: 1, borderRadius: 4 }}>
             <MenuToggle isToggleOn={isChecked} onPress={() => dispatch(setRegisterAccount(!isChecked))} >
-                Register on `r/demo/users` realm:
+                Register on `r/gnoland/users/v1` realm:
             </MenuToggle>
             <Ruller />
             {currentNetwork ?


### PR DESCRIPTION
This PR updates gnokey to use the latest version of the `users` realm to register users.

Note:
Because I can't query directly the `UserData` object like in the previous users realm, I have to get the full result and parse it in the new `convertToJson` function.
https://github.com/gnolang/gnokey-mobile/pull/53/files#diff-52d7f76e4737566ccd17bb7c4fb361bc0a9ef22151b3081155acf32892380bf4R230

I've opened an [issue](https://github.com/gnolang/gno/issues/3966)