### PR TITLE
fix: Use gnonative 4.7.2

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@bufbuild/protobuf": "^2.2.5",
         "@expo/vector-icons": "^15.0.2",
-        "@gnolang/gnonative": "^4.7.1",
+        "@gnolang/gnonative": "^4.7.2",
         "@gorhom/bottom-sheet": "^5.1.8",
         "@react-native-async-storage/async-storage": "2.2.0",
         "@react-native-clipboard/clipboard": "^1.16.2",
@@ -2922,9 +2922,9 @@
       }
     },
     "node_modules/@gnolang/gnonative": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/@gnolang/gnonative/-/gnonative-4.7.1.tgz",
-      "integrity": "sha512-Dc52U/GFBk2AafUWjY2R+mSKo+5Metqb6ZoFrINDGTkOyADKvFYT00A8IgB5HMwqsLZBiRdP3u2FZFL/WeNmRQ==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/@gnolang/gnonative/-/gnonative-4.7.2.tgz",
+      "integrity": "sha512-hiDMy1SoufEOCpuwzYceqDQ1Avl95XVUlcs/ZOd1IvXJ0o5fI8une4cg7+mCSyblI7DItryWdtgI/gg0dqQx9A==",
       "dependencies": {
         "@bufbuild/protobuf": "^2.6.2",
         "@connectrpc/connect": "^2.0.3",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@bufbuild/protobuf": "^2.2.5",
     "@expo/vector-icons": "^15.0.2",
-    "@gnolang/gnonative": "^4.7.1",
+    "@gnolang/gnonative": "^4.7.2",
     "@gorhom/bottom-sheet": "^5.1.8",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-clipboard/clipboard": "^1.16.2",


### PR DESCRIPTION
As explained in https://github.com/gnolang/gnonative/pull/215, we updated Gno Native Kit to fix some breaking changes. This made new [gnonative NPM package version 4.7.2](https://www.npmjs.com/package/@gnolang/gnonative/v/4.7.2). Therefore, we update to use it.