### PR TITLE
fix: Use gnonative 4.7.3

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@bufbuild/protobuf": "^2.2.5",
         "@expo/vector-icons": "^15.0.2",
-        "@gnolang/gnonative": "^4.7.2",
+        "@gnolang/gnonative": "^4.7.3",
         "@gorhom/bottom-sheet": "^5.1.8",
         "@react-native-async-storage/async-storage": "2.2.0",
         "@react-native-clipboard/clipboard": "^1.16.2",
@@ -2903,9 +2903,9 @@
       }
     },
     "node_modules/@gnolang/gnonative": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/@gnolang/gnonative/-/gnonative-4.7.2.tgz",
-      "integrity": "sha512-hiDMy1SoufEOCpuwzYceqDQ1Avl95XVUlcs/ZOd1IvXJ0o5fI8une4cg7+mCSyblI7DItryWdtgI/gg0dqQx9A==",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@gnolang/gnonative/-/gnonative-4.7.3.tgz",
+      "integrity": "sha512-xf2wlVSiLhutmmgRnUnCPFG+hpCrSP3Or/pMMOxOBjAq6e1pnwfK0YA2A/hxz/dH+88gtJLpfex/8k443OEENw==",
       "dependencies": {
         "@bufbuild/protobuf": "^2.6.2",
         "@connectrpc/connect": "^2.0.3",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@bufbuild/protobuf": "^2.2.5",
     "@expo/vector-icons": "^15.0.2",
-    "@gnolang/gnonative": "^4.7.2",
+    "@gnolang/gnonative": "^4.7.3",
     "@gorhom/bottom-sheet": "^5.1.8",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-clipboard/clipboard": "^1.16.2",


### PR DESCRIPTION
gnonative PR https://github.com/gnolang/gnonative/pull/217 is merged which fixes the DB implementation. This was causing transaction approval to print the error:
```
unary call error: [Error: invoke bridge method error: unknown: error initializing DB: resource temporarily unavailable]
```

Update to use the new gnonative npm package.