### PR TITLE
fix: use semantic-release-expo plugin for ios/android internal version

### DIFF
--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -1,8 +1,7 @@
 {
   "cli": {
     "version": ">= 7.8.2",
-    "promptToConfigurePushNotifications": false,
-    "appVersionSource": "remote"
+    "promptToConfigurePushNotifications": false
   },
   "build": {
     "development": {


### PR DESCRIPTION
use semantic-release-expo plugin for ios/android internal version to avoid duplicated version number.