### PR TITLE
fix: android internal version

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -4,6 +4,7 @@
     "slug": "gnokey",
     "platforms": ["ios", "android"],
     "version": "0.0.1",
+    "sdkVersion": "54.0.12",
     "orientation": "portrait",
     "scheme": "land.gno.gnokey",
     "icon": "./assets/images/icon.png",


### PR DESCRIPTION
There is a bug from semantic-release-expo that doesn't compute the Android version if `sdkVersion` is not set in `app.json`: https://github.com/byCedric/semantic-release-expo/issues/190#issuecomment-659040716