### PR TITLE
chore: mobile/README: Change to Android Studio Narwhal

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -45,7 +45,7 @@ Start a new terminal to get the changes to the environment .
 
 (optional) To install Android Studio, download and install the latest
 android-studio-{version}-mac.dmg from <https://developer.android.com/studio> .
-(Tested with Jellyfish 2023.3.1 .)
+(Tested with Narwhal 2025.1.1 .)
 
 ### Install requirements for Ubuntu 20.04, 22.04 and 24.04
 
@@ -64,7 +64,7 @@ Start a new terminal to get the changes to the environment .
 
 To install Android Studio, download the latest
 android-studio-{version}-linux.tar.gz from
-<https://developer.android.com/studio> . (Tested with Jellyfish 2023.3.1 .)
+<https://developer.android.com/studio> . (Tested with Narwhal 2025.1.1 .)
 In a terminal, enter the following with the correct {version}:
 
 ```sh


### PR DESCRIPTION
As we discussed, we can now build with the latest Android Studio, so update the README instructions.