### PR TITLE
feat: Estimate transaction fee

### DIFF
--- a/mobile/app/(app)/tosign/index.tsx
+++ b/mobile/app/(app)/tosign/index.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { router } from 'expo-router'
 import * as Linking from 'expo-linking'
 import {
-  estimateGasWantedAndSign,
+  estimateTxFeeAndSign,
   selectClientName,
   selectBech32Address,
   selectTxInput,
@@ -14,7 +14,7 @@ import {
   selectChainId,
   selectRemote,
   selectSignedTx,
-  selectGasWanted,
+  selectTxFee,
   selectLinkIsLoading
 } from '@/redux'
 import { useGnoNativeContext } from '@gnolang/gnonative'
@@ -28,6 +28,7 @@ import {
   Text,
   BetaVersionMiniBanner,
   Ruller,
+  formatter,
   CopyIcon
 } from '@/modules/ui-components'
 
@@ -44,7 +45,7 @@ export default function Page() {
   const chainId = useAppSelector(selectChainId)
   const remote = useAppSelector(selectRemote)
   const signedTx = useAppSelector(selectSignedTx)
-  const gasWanted = useAppSelector(selectGasWanted)
+  const txFee = useAppSelector(selectTxFee)
   const isLoading = useAppSelector(selectLinkIsLoading)
 
   const [gnonativeReady, setGnonativeReady] = useState(false)
@@ -79,7 +80,7 @@ export default function Page() {
 
         // need to pause to let the Keybase DB close before using it again
         // await new Promise((f) => setTimeout(f, 2000))
-        await dispatch(estimateGasWantedAndSign()).unwrap()
+        await dispatch(estimateTxFeeAndSign()).unwrap()
       } catch (error: unknown | Error) {
         console.error(error)
       }
@@ -144,9 +145,15 @@ export default function Page() {
               <FormItem label="Client" labelStyle={{ minWidth: 120 }} value={clientName} />
               <Ruller />
               <FormItem
-                label="Gas Wanted"
+                label="Tx Fee"
                 labelStyle={{ minWidth: 120 }}
-                value={gasWanted ? <Text.Body_Bold>{gasWanted?.toString()}</Text.Body_Bold> : <ActivityIndicator />}
+                value={
+                  txFee ? (
+                    <Text.Body_Bold>{`${formatter.balance(txFee)} GNOT (estimated)`}</Text.Body_Bold>
+                  ) : (
+                    <ActivityIndicator />
+                  )
+                }
               />
               <Ruller />
               <FormItem label="Reason" labelStyle={{ minWidth: 120 }} copyTextValue={reason} value={reason} />

--- a/mobile/app/home/vault/transfer-funds/confirm.tsx
+++ b/mobile/app/home/vault/transfer-funds/confirm.tsx
@@ -1,6 +1,6 @@
 import { Button, FormItem, HomeLayout, Ruller, ScreenHeader, Spacer, formatter } from '@/modules/ui-components'
 import {
-  selectTxGasWanted,
+  selectTransactionFee,
   selectVaultToEditWithBalance,
   useAppDispatch,
   useAppSelector,
@@ -11,7 +11,7 @@ import { useRouter } from 'expo-router'
 import { ScrollView } from 'react-native'
 
 const Page = () => {
-  const txGasWanted = useAppSelector(selectTxGasWanted)
+  const txFee = useAppSelector(selectTransactionFee)
   const dispatch = useAppDispatch()
   const vault = useAppSelector(selectVaultToEditWithBalance)
   const form = useAppSelector(selectTxForm)
@@ -19,7 +19,7 @@ const Page = () => {
 
   const broadcastTransfer = async () => {
     console.log('Broadcasting transactionx...')
-    if (!txGasWanted || !vault) return
+    if (!txFee || !vault) return
     try {
       console.log('Broadcasting transaction...')
       await dispatch(txBroadcast({ fromAddress: vault.keyInfo.address })).unwrap()
@@ -33,8 +33,8 @@ const Page = () => {
     <HomeLayout
       header={<ScreenHeader title="Summary" />}
       footer={
-        <Button onPress={broadcastTransfer} color="primary" disabled={!txGasWanted}>
-          {txGasWanted ? 'Confirm' : 'Loading...'}
+        <Button onPress={broadcastTransfer} color="primary" disabled={!txFee}>
+          {txFee ? 'Confirm' : 'Loading...'}
         </Button>
       }
     >
@@ -49,7 +49,7 @@ const Page = () => {
         <Ruller spacer={4} />
         <FormItem label="Amount" value={`${form.amount} GNOT`} />
         <Ruller spacer={4} />
-        <FormItem label="Gas Fee" value={`${formatter.balance(txGasWanted)} GNOT (estimated)`} />
+        <FormItem label="Tx Fee" value={`${formatter.balance(txFee)} GNOT (estimated)`} />
         <Ruller spacer={4} />
         <FormItem label="Memo" value={form.memo} />
         <Ruller spacer={4} />

--- a/mobile/app/home/vault/transfer-funds/index.tsx
+++ b/mobile/app/home/vault/transfer-funds/index.tsx
@@ -1,7 +1,7 @@
 import { Button, HomeLayout, ScreenHeader, Spacer, Text, TextInputLabel, VaultItem } from '@/modules/ui-components'
 import TextFieldForm from '@/modules/ui-components/organisms/input/TextFieldForm'
 import {
-  txGasFeeEstimation,
+  txFeeEstimation,
   selectVaultToEditWithBalance,
   useAppSelector,
   selectTxFormMemo,
@@ -30,7 +30,7 @@ const Page = () => {
   const prepareTransfer = () => {
     if (!vault) return
     try {
-      dispatch(txGasFeeEstimation())
+      dispatch(txFeeEstimation())
       router.push('/home/vault/transfer-funds/confirm')
     } catch (error) {
       console.error('Transfer failed:', error)

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@bufbuild/protobuf": "^2.2.5",
         "@expo/vector-icons": "^15.0.2",
-        "@gnolang/gnonative": "^4.7.3",
+        "@gnolang/gnonative": "^4.8.0",
         "@gorhom/bottom-sheet": "^5.1.8",
         "@react-native-async-storage/async-storage": "2.2.0",
         "@react-native-clipboard/clipboard": "^1.16.2",
@@ -2903,9 +2903,9 @@
       }
     },
     "node_modules/@gnolang/gnonative": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/@gnolang/gnonative/-/gnonative-4.7.3.tgz",
-      "integrity": "sha512-xf2wlVSiLhutmmgRnUnCPFG+hpCrSP3Or/pMMOxOBjAq6e1pnwfK0YA2A/hxz/dH+88gtJLpfex/8k443OEENw==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@gnolang/gnonative/-/gnonative-4.8.0.tgz",
+      "integrity": "sha512-ofV9U0+37kAPQ2p8yuYebjP5dg0G1TQ9lu8Pa/0KAaIX/jsS/e401460BOlm2ygKTnpAyn00uJpdZU3Yj3KeUA==",
       "dependencies": {
         "@bufbuild/protobuf": "^2.6.2",
         "@connectrpc/connect": "^2.0.3",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@bufbuild/protobuf": "^2.2.5",
     "@expo/vector-icons": "^15.0.2",
-    "@gnolang/gnonative": "^4.7.3",
+    "@gnolang/gnonative": "^4.8.0",
     "@gorhom/bottom-sheet": "^5.1.8",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-clipboard/clipboard": "^1.16.2",


### PR DESCRIPTION
Gno Native Kit 4.8.0 is released which includes `estimateTxFees`. We update to show the estimated transaction fee instead of gas wanted.

* In package.json, use @gnolang/gnonative 4.8.0
* In linkingSlice and transactions.ts, add `DEFAULT_STORAGE_MARGIN` as 100% . (We don't need a margin since the simulation computes the storage fee exactly.)
* Use `gnonative.estimateTxFees` instead of `gnonative.estimateGas`. Generally change variables and function names from "gasWanted" to "txFee"
* On the Transfer Funds Summary screen, show the Tx Fee
* On the tosign confirmation screen, show the Tx Fee. Use the same `${formatter.balance(txFee)} GNOT (estimated)` formatting as the Transfer Funds Summary screen

<img width="325" height="640" alt="image" src="https://github.com/user-attachments/assets/38a77ee3-df73-434b-9ac2-72c95608378c" />

