### PR TITLE
fix: In pasteClipboard, properly import the expo Clipboard

### DIFF
--- a/mobile/app/home/vault/option-phrase/enter-phrase.tsx
+++ b/mobile/app/home/vault/option-phrase/enter-phrase.tsx
@@ -10,7 +10,7 @@ import {
   TouchableWithoutFeedback,
   StyleSheet
 } from 'react-native'
-import Clipboard from 'expo-clipboard'
+import * as Clipboard from 'expo-clipboard'
 import { useAppDispatch, setPhrase, resetAddVaultState, checkPhrase } from '@/redux'
 import { useRouter, useFocusEffect } from 'expo-router'
 import styled from 'styled-components/native'


### PR DESCRIPTION
As we discussed, we need to properly import the expo Clipboard to use it in `pasteClipboard`.